### PR TITLE
Fix unit tests and syntax errors

### DIFF
--- a/dojo/tools/blackduck/importer.py
+++ b/dojo/tools/blackduck/importer.py
@@ -66,7 +66,7 @@ class BlackduckImporter(Importer):
                     issue[17],  # remediation target date
                     issue[18],  # remediation actual date
                     issue[19],  # remediation comment
-                    ', '.join([location for location in locations])
+                    ', '.join(locations)
                 )
 
     # return type elided due to higher kinded types bug in Python 3.5

--- a/dojo/tools/blackduck/model.py
+++ b/dojo/tools/blackduck/model.py
@@ -1,2 +1,23 @@
-class BlackduckFinding:
-    pass
+from collections import namedtuple
+
+
+# this class can be updated to use @dataclass in Python 3.7
+# note that all types are strings except for 'locations' which is a set of strings
+BlackduckFinding = namedtuple('BlackduckFinding', [
+    'vuln_id',
+    'description',
+    'security_risk',
+    'impact',
+    'vuln_source',
+    'url',
+    'channel_version_origin_id',
+    'published_date',
+    'updated_date',
+    'base_score',
+    'exploitability',
+    'remediation_status',
+    'remediation_target_date',
+    'remediation_actual_date',
+    'remediation_comment',
+    'locations'
+])

--- a/dojo/unittests/test_blackduck_csv_parser.py
+++ b/dojo/unittests/test_blackduck_csv_parser.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from dojo.tools.blackduck.parser import BlackduckHubCSVParser
 from dojo.models import Test
+from pathlib import Path
 
 
 class TestBlackduckHubParser(TestCase):
@@ -22,7 +23,6 @@ class TestBlackduckHubParser(TestCase):
     #     self.assertEqual(24, len(parser.items))
 
     def test_blackduck_enhanced_has_many_findings(self):
-        testfile = open("dojo/unittests/scans/blackduck/blackduck_enhanced_py3_unittest.zip")
+        testfile = Path("dojo/unittests/scans/blackduck/blackduck_enhanced_py3_unittest.zip")
         parser = BlackduckHubCSVParser(testfile, Test())
-        testfile.close()
         self.assertEqual(11, len(parser.items))


### PR DESCRIPTION
Notes:

* string::join takes an iterable, so no need to re-iterate over them.
* Need to use `namedtuple()` for something comparable to `@dataclass` added in Python 3.7.
* Importer API takes a path, not an open file, since it opens and closes the file itself. This might be a relic from when I originally wrote this in Java, but it still makes sense here. The test failure seen was related to this API mismatch. (sneers in static typing land)